### PR TITLE
Remove redundant key

### DIFF
--- a/lib/people.rb
+++ b/lib/people.rb
@@ -276,9 +276,6 @@ module People
         :parsed      => false,
         :parse_type  => "",
 
-        :parsed      => false,
-        :parse_type  => "",
-
         :parsed2     => false,
         :parse_type2 => "",
 


### PR DESCRIPTION
This causes a warning starting in Ruby 2.2.0.

```
/gems/ruby-2.2.0/gems/people-0.2.1/lib/people.rb:276: warning: duplicated key at line 279 ignored: :parsed
/gems/ruby-2.2.0/gems/people-0.2.1/lib/people.rb:277: warning: duplicated key at line 280 ignored: :parse_type
```
