### PR TITLE
Remove duplicate keys

### DIFF
--- a/lib/people.rb
+++ b/lib/people.rb
@@ -276,9 +276,6 @@ module People
         :parsed      => false,
         :parse_type  => "",
 
-        :parsed      => false,
-        :parse_type  => "",
-
         :parsed2     => false,
         :parse_type2 => "",
 


### PR DESCRIPTION
The keys `:parsed` and `:parse_type` are present in the return hash twice. This pull request removes one occurrence each.
