### PR TITLE
Fixes Duplicate Key Warnings

### DIFF
--- a/lib/people.rb
+++ b/lib/people.rb
@@ -276,9 +276,6 @@ module People
         :parsed      => false,
         :parse_type  => "",
 
-        :parsed      => false,
-        :parse_type  => "",
-
         :parsed2     => false,
         :parse_type2 => "",
 


### PR DESCRIPTION
Fixes the following two warnings about duplicate hash keys:

```
/Users/***/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/people-0.2.1/lib/people.rb:276: warning: duplicated key at line 279 ignored: :parsed
/Users/***/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/people-0.2.1/lib/people.rb:277: warning: duplicated key at line 280 ignored: :parse_type
```
