### PR TITLE
remove duplicate keys that were causing a warning

### DIFF
--- a/lib/people.rb
+++ b/lib/people.rb
@@ -276,9 +276,6 @@ module People
         :parsed      => false,
         :parse_type  => "",
 
-        :parsed      => false,
-        :parse_type  => "",
-
         :parsed2     => false,
         :parse_type2 => "",
 


### PR DESCRIPTION
Ruby kept complaining:

gems/people-0.2.1/lib/people.rb:276: warning: key :parsed is duplicated and overwritten on line 279
gems/people-0.2.1/lib/people.rb:277: warning: key :parse_type is duplicated and overwritten on line 280

So I deleted the duplicate keys.  Thanks for the gem!
